### PR TITLE
Add both migrations to create and drop the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+/spec/testapp/
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/lib/systematize/version.rb
+++ b/lib/systematize/version.rb
@@ -1,3 +1,3 @@
 module Systematize
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -24,4 +24,14 @@ namespace :systematize do
       ActiveRecord::Migrator.migrate(temp_folder, 0)
     end
   end
+
+  desc "Create the database"
+  task :create => :environment do
+    Rake::Task["db:create"].invoke
+  end
+
+  desc "Drop the database"
+  task :drop => :environment do
+    Rake::Task["db:drop"].invoke
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,24 @@
 require 'rspec'
 require 'rails'
+require 'active_record'
 require 'systematize'
 require 'pry'
+
+DATABASE_SPEC_FILE = 'spec/support/db/test.sqlite3'
 
 RSpec.configure do |config|
   config.color = true
   config.tty = true
+
+  config.before(:suite) {
+    ActiveRecord::Base.establish_connection(
+      adapter: 'sqlite3',
+      database: DATABASE_SPEC_FILE,
+    )
+  }
+
+  config.after(:suite) {
+    FileUtils.rm(DATABASE_SPEC_FILE)
+    ActiveRecord::Base.connection.close
+  }
 end

--- a/systematize.gemspec
+++ b/systematize.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency('pry')
   spec.add_development_dependency('rspec')
+  spec.add_development_dependency('sqlite3')
 
 end


### PR DESCRIPTION
Add both migrations to create and drop the database. Also the specs were not running locally due to the database not being setup properly.

This PR was created due to the [issue](https://github.com/RicardoBrazao/systematize/issues/6).